### PR TITLE
Fix burn after read toggle visibility

### DIFF
--- a/Demo/app/src/main/java/io/openim/android/demo/ui/search/PersonDetailActivity.java
+++ b/Demo/app/src/main/java/io/openim/android/demo/ui/search/PersonDetailActivity.java
@@ -113,8 +113,8 @@ public class PersonDetailActivity extends BaseActivity<SearchVM, ActivityPersonD
 
         update();
 
-        if (formChat) {
-            conversationId = "single_" + vm.searchContent.getValue();
+        conversationId = "single_" + vm.searchContent.getValue();
+        if (!oneself() && TextUtils.isEmpty(groupId)) {
             view.readVanishLy.setVisibility(View.VISIBLE);
             readVanishSwitch = view.readVanishSwitch;
             boolean on = SharedPreferencesUtil.get(this)


### PR DESCRIPTION
## Summary
- make burn-after-read toggle visible for all user details

## Testing
- `./gradlew assemble` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_6843329023a0833288bd91dbedd8d378