### PR TITLE
Add burn after read toggle

### DIFF
--- a/Demo/app/src/main/res/layout/activity_person_detail.xml
+++ b/Demo/app/src/main/res/layout/activity_person_detail.xml
@@ -299,11 +299,38 @@
                         android:textColor="#ff333333"
                         android:textSize="18sp" />
 
-                    <ImageView
-                        android:layout_width="wrap_content"
+                <ImageView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginRight="22dp"
+                    android:src="@mipmap/ic_right" />
+
+                </LinearLayout>
+
+                <LinearLayout
+                    android:id="@+id/readVanishLy"
+                    android:layout_width="match_parent"
+                    android:layout_height="55dp"
+                    android:layout_marginTop="12dp"
+                    android:background="@color/white"
+                    android:gravity="center_vertical"
+                    android:orientation="horizontal"
+                    android:visibility="gone">
+
+                    <TextView
+                        android:layout_width="0dp"
                         android:layout_height="wrap_content"
-                        android:layout_marginRight="22dp"
-                        android:src="@mipmap/ic_right" />
+                        android:layout_marginLeft="22dp"
+                        android:layout_weight="1"
+                        android:gravity="center_vertical"
+                        android:text="@string/read_vanish"
+                        android:textColor="#ff333333"
+                        android:textSize="18sp" />
+
+                    <io.openim.android.ouicore.widget.SlideButton
+                        android:id="@+id/readVanishSwitch"
+                        android:layout_width="45dp"
+                        android:layout_height="25dp" />
 
                 </LinearLayout>
 


### PR DESCRIPTION
## Summary
- add a burn after read toggle section in personal detail screen
- persist toggle state and notify peer via custom message

## Testing
- `./gradlew test --quiet` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_684329643c808332b830fbca294ff5c6