### PR TITLE
Implement vanish timer for burn after reading

### DIFF
--- a/OUIKit/OUICore/src/main/java/io/openim/android/ouicore/utils/Constants.java
+++ b/OUIKit/OUICore/src/main/java/io/openim/android/ouicore/utils/Constants.java
@@ -124,6 +124,10 @@ public class Constants {
     public static final String K_LOG_LEVEL = "logLevel";
     // 阅后即焚存储标识
     public static final String SP_Prefix_ReadVanish = "ReadVanish_";
+    // 阅后即焚时间存储标识
+    public static final String SP_Prefix_ReadVanishTime = "ReadVanishTime_";
+    // 默认阅后即焚时间(秒)
+    public static final int DEFAULT_VANISH_SECOND = 10;
 
 
     //加载中


### PR DESCRIPTION
## Summary
- add constants for burn-after-read timers
- allow choosing burn-after-read seconds in `PersonDetailActivity`
- auto delete private messages after read timeout in `ChatVM`

## Testing
- `gradlew assemble` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68433f2c5dd083328559db5f911909e8