### PR TITLE
Fix SharedPreferences Long retrieval crash

### DIFF
--- a/OUIKit/OUICore/src/main/java/io/openim/android/ouicore/utils/SharedPreferencesUtil.java
+++ b/OUIKit/OUICore/src/main/java/io/openim/android/ouicore/utils/SharedPreferencesUtil.java
@@ -77,7 +77,12 @@ public class SharedPreferencesUtil {
     }
 
     public long getLong(String key) {
-        return sharedPreference.getLong(key, 0);
+        try {
+            return sharedPreference.getLong(key, 0);
+        } catch (ClassCastException e) {
+            // In previous versions values might be stored as Integer
+            return sharedPreference.getInt(key, 0);
+        }
     }
 
     public float getFloat(String key) {


### PR DESCRIPTION
## Summary
- handle `ClassCastException` when retrieving long values from preferences

## Testing
- `./gradlew assemble` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_6843bf6aa6cc8332b14b03cbb99cef92